### PR TITLE
feat: supports `think` option

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -58,6 +58,12 @@ This module has some options.
   for the chat model. For example, you can use it to specify the role or
   instructions that the model should follow when processing the input.
 
+=item * C<think> X<tataku-processor-ollama-options-think>
+
+  (optional) Enable model thinking.
+  Use true/false or specify a level ("high" | "medium" | "low").
+  Requires model support.
+
 =back
 
 =head2 Samples X<tataku-processor-ollama-samples>

--- a/README.pod
+++ b/README.pod
@@ -61,7 +61,7 @@ This module has some options.
 =item * C<think> X<tataku-processor-ollama-options-think>
 
   (optional) Enable model thinking.
-  Use true/false or specify a level ("high" | "medium" | "low").
+  Use C<true>/C<false> or specify a level (C<"high"> | C<"medium"> | C<"low">).
   Requires model support.
 
 =back

--- a/denops/@tataku/processor/ollama.ts
+++ b/denops/@tataku/processor/ollama.ts
@@ -11,6 +11,7 @@ type Option = {
   model: string;
   silent: boolean;
   systemPrompt?: string;
+  think?: boolean | "high" | "medium" | "low";
 };
 
 const isOption = is.ObjectOf({
@@ -18,13 +19,20 @@ const isOption = is.ObjectOf({
   model: as.Optional(is.String),
   silent: as.Optional(is.Boolean),
   systemPrompt: as.Optional(is.String),
+  think: as.Optional(is.UnionOf([
+    is.Boolean,
+    is.LiteralOf("high"),
+    is.LiteralOf("medium"),
+    is.LiteralOf("low"),
+  ])),
 }) satisfies Predicate<Partial<Option>>;
 
-const defaults: Option = {
+const defaults = {
   endpoint: "http://localhost:11434",
   model: "codellama",
   silent: false,
-};
+  think: false,
+} as const satisfies Option;
 
 const notify = async (denops: Denops, message: string, option: Option) => {
   if (option.silent) {
@@ -55,6 +63,7 @@ const processor: ProcessorFactory = (denops: Denops, option: unknown) => {
         model: opt.model,
         messages: messages,
         stream: true,
+        think: opt.think,
       });
       for await (const r of response) {
         if (r.done) {

--- a/denops/@tataku/processor/ollama.ts
+++ b/denops/@tataku/processor/ollama.ts
@@ -3,7 +3,7 @@ import { as, ensure, is, type Predicate } from "jsr:@core/unknownutil@4.3.0";
 import { echo } from "jsr:@denops/std@7.6.0/helper/echo";
 import { toTransformStream } from "jsr:@std/streams@1.0.11/to-transform-stream";
 import { Ollama } from "npm:ollama@0.5.17/browser";
-import type { Message } from "npm:ollama@0.5.17/interfaces";
+import type { Message } from "npm:ollama@0.5.17";
 import { ProcessorFactory } from "jsr:@omochice/tataku-vim@1.2.1";
 
 type Option = {


### PR DESCRIPTION
Some models support `think` option to output their thinking.

It is useful but sometime noisy.

We should make customizable it.

- **chore: upgrade ollama.js to 0.5.17**
- **feat: support `think` option**
- **docs: add a document for `think`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional “think” setting for the Ollama processor to enable model thinking. Supports true/false or levels ("low", "medium", "high"). Defaults to off and remains backward compatible. Requires model support.

- Documentation
  - Updated README with details and examples for the new “think” option, including accepted values and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->