### PR TITLE
chore: disable no-import-prefix

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,5 +5,12 @@
     "check": "deno check ./**/*.ts",
     "lint": "deno lint ./**/*.ts"
   },
-  "lock": false
+  "lock": false,
+  "lint": {
+    "rules": {
+      "exclude": [
+        "no-import-prefix"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
we dont use deno.lock and deno.jsonc (what is differ from package.json?)
